### PR TITLE
FIX: adjust diffuse_stepwise behavior for anndata version

### DIFF
--- a/cna/tools/_nam.py
+++ b/cna/tools/_nam.py
@@ -2,9 +2,14 @@ import numpy as np
 import pandas as pd
 import warnings
 import scipy.stats as st
+import anndata
+from packaging import version
 
 def diffuse_stepwise(data, s, maxnsteps=15):
-    a = data.uns['neighbors']['connectivities']
+        if version.parse(anndata.__version__) < version.parse("0.7.2"):
+        a = data.uns["neighbors"]["connectivities"]
+    else:
+        a = data.obsp["distances"]
     colsums = np.array(a.sum(axis=0)).flatten() + 1
 
     for i in range(maxnsteps):

--- a/cna/tools/_nam.py
+++ b/cna/tools/_nam.py
@@ -6,7 +6,7 @@ import anndata
 from packaging import version
 
 def diffuse_stepwise(data, s, maxnsteps=15):
-        if version.parse(anndata.__version__) < version.parse("0.7.2"):
+    if version.parse(anndata.__version__) < version.parse("0.7.2"):
         a = data.uns["neighbors"]["connectivities"]
     else:
         a = data.obsp["distances"]

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setuptools.setup(
     python_requires='>=3.6',
     install_requires=[
         'multianndata',
+        "anndata",
         'numpy',
         'pandas',
         'scipy',


### PR DESCRIPTION
Since version [version 0.7.2](https://anndata.readthedocs.io/en/latest/#id1), anndata objects store their connectivity data in the `.obsp['neighbors']` instead of in `.uns['neighbors']['connectivities']`.  The latter location, however, is where `cna.tools_nam. diffuse_stepwise()` looks for the data, causing `cna` to fail on newer anndata objects.  I've added a bit so that `diffuse_stepwise()` will check version and adjust its behavior accordingly.

Part 1 of 3 from #1 